### PR TITLE
Quick retain/release cleanup

### DIFF
--- a/syphon_cxx.hpp
+++ b/syphon_cxx.hpp
@@ -28,6 +28,7 @@ struct _serverOpaquePtr;
 struct _clientOpaquePtr;
 struct _serverOptionsOpaquePtr;
 struct _serverDescriptionOpaquePtr;
+struct _imageOpaquePtr;
 
 // ---
 
@@ -98,9 +99,13 @@ using NewFrameHandlerFunc = std::function<void(ClientPtr)>;
 const NewFrameHandlerFunc emptyFrameHandler = [](ClientPtr) {};
 
 // ---
-struct Image {
-    GLuint textureName;
-    Size textureSize;
+class Image {
+    _imageOpaquePtr *_obj = nullptr;
+public:
+    Image(_imageOpaquePtr *i = nullptr);
+    ~Image();
+    GLuint textureName();
+    Size textureSize();
 };
 
 // ---

--- a/wrapper.cpp
+++ b/wrapper.cpp
@@ -73,8 +73,8 @@ PYBIND11_MODULE(syphonpy, m)
 
     // ---
     py::class_<Wrapper::Image>(m, "Image")
-        .def_readwrite("texture_name", &Wrapper::Image::textureName)
-        .def_readwrite("texture_size", &Wrapper::Image::textureSize)
+        .def("texture_name", &Wrapper::Image::textureName)
+        .def("texture_size", &Wrapper::Image::textureSize)
         //
         ;
 


### PR DESCRIPTION
Hey - great to see a Python Syphon wrapper.

There's a lot of leaking - GL textures, servers and clients all get leaked by improper Objective C memory management. I've attempted to clean things up quickly this morning *but*

1. this compiles but isn't tested, I may have made mistakes
2. my changes are verbose and hacky - I won't be offended if you want to improve on it

Objective C methods with `init`, `copy` or `new` in their names all increase the reference count and should be matched with a corresponding `release`.